### PR TITLE
Solución a problemas de conexión de terminal a fortes backend

### DIFF
--- a/apps/backend/src/modules/docker/services/DockerTaskService.js
+++ b/apps/backend/src/modules/docker/services/DockerTaskService.js
@@ -182,7 +182,7 @@ export const runTerminalOnRemoteTaskContainer = function (nodeId, containerId, t
             if(response.status == 200){
                 const { WebSocket, WebSocketServer } = require('ws');
                 const webSocketServer = new WebSocketServer({ port: 9995 }); //Inicializacion de WSS en back
-                const agentWSClient = new WebSocket(`ws://${DNS}:${process.env.AGENTWSSPORT}`); //Conexion a WSS del agent
+                const agentWSClient = new WebSocket(`ws://${DNS}:${process.env.AGENTWSSPORT ? process.env.AGENTWSSPORT : 9997}`); //Conexion a WSS del agent
 
                 webSocketServer.on('connection', (backWS) => {
                     backWS.on('close', () => {

--- a/apps/frontend/src/modules/docker/components/ServiceTasks/ServiceTasks.vue
+++ b/apps/frontend/src/modules/docker/components/ServiceTasks/ServiceTasks.vue
@@ -74,8 +74,15 @@ export default {
       axios.get(`/api/docker/task/${task.nodeId}/${task.containerId}/runTerminal/bash`)
           .then((response) => {
             if (response.data == 'Linked') {
-              const connectionToBackWSS = new WebSocket('ws://127.0.0.1:9995')
-              this.webSocket = connectionToBackWSS
+              const WSSURL = window.location.origin.replace(/http/, "ws").replace(/:[0-9]+/,':9995')
+              
+              try{
+                const connectionToBackWSS = new WebSocket(WSSURL)
+                this.webSocket = connectionToBackWSS
+              } catch (error){
+                console.error(error)
+              }
+              
             }
           });
 

--- a/apps/frontend/src/modules/docker/pages/WebTerminalPage/WebTerminalPage.vue
+++ b/apps/frontend/src/modules/docker/pages/WebTerminalPage/WebTerminalPage.vue
@@ -37,8 +37,13 @@ export default {
       axios.get(`/api/docker/task/${this.nodeId}/${this.containerId}/runTerminal/bash`)
           .then((response) => {
             if (response.data == 'Linked') {
-              const connectionToBackWSS = new WebSocket('ws://127.0.0.1:9995')
-              this.webSocket = connectionToBackWSS
+              try{
+                const BackWSSURL = window.location.origin.replace(/http/, "ws").replace(/:[0-9]+/,':9995')
+                const connectionToBackWSS = new WebSocket(BackWSSURL)
+                this.webSocket = connectionToBackWSS
+              } catch (error){
+                console.error(error)
+              }
             }
           });
 


### PR DESCRIPTION
Changed WebTerminal's way of getting backend's WSS URL & Agent's WSS default port updated to 9997