### PR TITLE
Fix to ticket #76554: the API serviceCreate endpoint now handles the case in which the service already existed by updating it

### DIFF
--- a/apps/backend/src/modules/docker/routes/DockerLogsRoutes.js
+++ b/apps/backend/src/modules/docker/routes/DockerLogsRoutes.js
@@ -1,56 +1,44 @@
 import express from 'express'
 import http from "http";
 import { DOCKER_VIEW } from '../permissions/dockerPermissions';
-import { AuthenticationError, ForbiddenError, UserInputError } from 'apollo-server-express';
+import { AuthenticationError, ForbiddenError } from 'apollo-server-express';
 import { fetchTask, findTaskLogs } from '../services/DockerTaskService';
 import { getSettingsValueByKey } from '@dracul/settings-backend';
 
+const validateStatusCode = (statusCode) => http.STATUS_CODES.hasOwnProperty(statusCode)
 
-var router = express.Router();
-
-function validateStatusCode(statusCode){
-    return http.STATUS_CODES.hasOwnProperty(statusCode)
-}
+let router = express.Router();
 
 router.get('/docker/logs/:stackName/:serviceName', async function (req, res) {
     try {
+        if (!req.user) throw new AuthenticationError("Not Authorized")
+        if (!req.rbac.isAllowed(req.user.id, DOCKER_VIEW)) throw new ForbiddenError("Not Authorized")
+
         const {stackName, serviceName} = req.params
-        const {lines = 1    , search = ''} = req.query
+        const {lines = 30, search = ''} = req.query
 
-        const maxLogsLines = await getSettingsValueByKey('maxLogsLines')
+        const maxLogsLines = Number(await getSettingsValueByKey('maxLogsLines'))
+        if(Number(lines) > Number(maxLogsLines) || lines === 'all') throw new Error('Lines limit is exceeded')
 
-        if(lines > await getSettingsValueByKey('maxLogsLines' || lines === 'all')){
-            throw new Error('Lines limit is exceeded')
-        }
-
-        const user = req.user
-        if(!user) throw new AuthenticationError("Not Authorized")
-        if(!req.rbac.isAllowed(user.id, DOCKER_VIEW)) throw new ForbiddenError("Not Authorized")
 
         const tasks = await fetchTask(`${stackName}_${serviceName}`)
         let firstTaskRunning = null
 
         tasks.forEach(task => {
-            if(firstTaskRunning != null) return
-            if(task.state === 'running') firstTaskRunning = task
+            if (task.state === 'running' && !firstTaskRunning) firstTaskRunning = task
         })
 
-        if(firstTaskRunning === null) return res.send('task not found')
+        if (!firstTaskRunning) return res.send('task not found')
 
-        let taskLogs = await findTaskLogs(firstTaskRunning.id, {
+        const taskLogs = (await findTaskLogs(firstTaskRunning.id, {
             fetch: search,
             tail: lines
-        })
-
-        taskLogs = taskLogs.map(({text}) => {
-            return text
-        })
+        })).map(({text}) => text)
 
         return res.json(taskLogs)
-    } catch (e) {
-        let statusCode = (e.statusCode && validateStatusCode(e.statusCode)) ? e.statusCode : 500
-        res.status(statusCode)
-        res.send(e.message)
+    } catch (error) {
+        const statusCode = (error.statusCode && validateStatusCode(error.statusCode)) ? error.statusCode : 500
+        res.status(statusCode).send(error.message)
     }
 })
 

--- a/apps/backend/src/modules/docker/routes/DockerServiceRoutes.js
+++ b/apps/backend/src/modules/docker/routes/DockerServiceRoutes.js
@@ -7,12 +7,13 @@ import {
     findServiceTag
 } from "../services/DockerService";
 import http from "http";
-import {serviceStats, serviceStatsByName, taskStats} from "../services/DockerStatsService";
+import { serviceStatsByName } from "../services/DockerStatsService";
 import { AuthenticationError, ForbiddenError } from 'apollo-server-express';
 import { DOCKER_CREATE, DOCKER_UPDATE, DOCKER_VIEW } from '../permissions/dockerPermissions';
 
 
-var router = express.Router();
+let router = express.Router();
+router.use(express.json());
 
 function validateStatusCode(statusCode){
     return http.STATUS_CODES.hasOwnProperty(statusCode)
@@ -20,120 +21,104 @@ function validateStatusCode(statusCode){
 
 router.get('/docker/service', async function (req, res) {
     try {
-        const user = req.user;
-        if(!user)  throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto");
-        if(!req.rbac.isAllowed(user.id, DOCKER_VIEW)) throw new ForbiddenError("Not Authorized");
+        if(!req.user)  throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto")
+        if(!req.rbac.isAllowed(req.user.id, DOCKER_VIEW)) throw new ForbiddenError("Not Authorized")
 
-        let r = await fetchService()
-        res.json(r)
+        res.json(await fetchService())
+    } catch (error) {
+        const statusCode = (error.statusCode && validateStatusCode(error.statusCode)) ? error.statusCode : 500
 
-    } catch (e) {
-        let statusCode = (e.statusCode && validateStatusCode(e.statusCode)) ? e.statusCode : 500
         res.status(statusCode)
-        res.send(e.message)
+        res.send(error.message)
     }
 })
 
 
 router.post('/docker/service', async function (req, res) {
     try {
-        let user = req.user
-        if(!user)  throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto")
-        if(!req.rbac.isAllowed(user.id, DOCKER_CREATE)) throw new ForbiddenError("Not Authorized")
+        if(!req.user)  throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto")
+        if(!req.rbac.isAllowed(req.user.id, DOCKER_CREATE)) throw new ForbiddenError("Not Authorized")
 
-        let body = req.body
+        res.json(await dockerServiceCreate(req.user, req.body))
+    } catch (error) {
+        const statusCode = (error.statusCode && validateStatusCode(error.statusCode)) ? error.statusCode : 500
 
-        let r = await dockerServiceCreate(user, body)
-        res.json(r)
-    } catch (e) {
-        let statusCode = (e.statusCode && validateStatusCode(e.statusCode)) ? e.statusCode : 500
-        res.status(statusCode)
-        res.send(e.message)
+        if (error.message.includes('Service already exists')) {
+            const existentServiceID = error.message.match(/[a-z0-9]{25}/)[0]
+            res.json(await dockerServiceUpdate(req.user, existentServiceID, req.body))
+        } else {
+            res.status(statusCode)
+            res.send(error.message)    
+        }
     }
-
 })
 
 router.put('/docker/service/:service', async function (req, res) {
     try {
-        let user = req.user
-        if(!user)  throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto")
-        if(!req.rbac.isAllowed(user.id, DOCKER_UPDATE)) throw new ForbiddenError("Not Authorized")
+        if(!req.user)  throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto")
+        if(!req.rbac.isAllowed(req.user.id, DOCKER_UPDATE)) throw new ForbiddenError("Not Authorized")
 
-        let body = req.body
-        let serviceId = req.params.service
+        res.json(await dockerServiceUpdate(req.user, req.params.service, req.body))
+    } catch (error) {
+        const statusCode = (error.statusCode && validateStatusCode(error.statusCode)) ? error.statusCode : 500
 
-        let r = await dockerServiceUpdate(user, serviceId, body)
-        res.json(r)
-    } catch (e) {
-        let statusCode = (e.statusCode && validateStatusCode(e.statusCode)) ? e.statusCode : 500
         res.status(statusCode)
-        res.send(e.message)
+        res.send(error.message)
     }
-
 })
 
 router.get('/docker/service/:name', async function (req, res) {
     try {
-        const user = req.user;
-        if(!user)  throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto");
-        if(!req.rbac.isAllowed(user.id, DOCKER_VIEW)) throw new ForbiddenError("Not Authorized");
+        if(!req.user)  throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto")
+        if(!req.rbac.isAllowed(req.user.id, DOCKER_VIEW)) throw new ForbiddenError("Not Authorized")
 
-        let r = await findServiceByName(req.params.name)
-        res.json(r)
-
-    } catch (e) {
-        res.status(e.message === "Service not found" ? 404 : 500)
-        res.send(e.message)
+        res.json(await findServiceByName(req.params.name))
+    } catch (error) {
+        res.status(error.message === "Service not found" ? 404 : 500)
+        res.send(error.message)
     }
 })
 
 router.get('/docker/service/:name/tag', async function (req, res) {
     try {
-        const user = req.user;
-        if(!user)  throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto");
-        if(!req.rbac.isAllowed(user.id, DOCKER_VIEW)) throw new ForbiddenError("Not Authorized");
+        if(!req.user)  throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto")
+        if(!req.rbac.isAllowed(req.user.id, DOCKER_VIEW)) throw new ForbiddenError("Not Authorized")
 
+        res.json(await findServiceTag(req.params.name))
+    } catch (error) {
+        const statusCode = (error.statusCode && validateStatusCode(error.statusCode)) ? error.statusCode : 500
 
-        let r = await findServiceTag(req.params.name)
-        res.json(r)
-
-    } catch (e) {
-        let statusCode = (e.statusCode && validateStatusCode(e.statusCode)) ? e.statusCode : 500
         res.status(statusCode)
-        res.send(e.message)
+        res.send(error.message)
     }
 })
 
 
 router.get('/docker/service/:serviceName/stats', async function (req, res) {
     try {
-        const user = req.user;
-        if(!user)  throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto");
-        if(!req.rbac.isAllowed(user.id, DOCKER_VIEW)) throw new ForbiddenError("Not Authorized");
+        if (!req.user) throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto")
+        if (!req.rbac.isAllowed(req.user.id, DOCKER_VIEW)) throw new ForbiddenError("Not Authorized")
 
-        let r = await serviceStatsByName(req.params.serviceName)
-        res.json(r)
+        res.json(await serviceStatsByName(req.params.serviceName))
+    } catch (error) {
+        const statusCode = (error.statusCode && validateStatusCode(error.statusCode)) ? error.statusCode : 500
 
-    } catch (e) {
-        let statusCode = (e.statusCode && validateStatusCode(e.statusCode)) ? e.statusCode : 500
         res.status(statusCode)
-        res.send(e.message)
+        res.send(error.message)
     }
 })
 
 router.get('/docker/service/id/:serviceId/stats', async function (req, res) {
     try {
-        const user = req.user;
-        if(!user)  throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto");
-        if(!req.rbac.isAllowed(user.id, DOCKER_VIEW)) throw new ForbiddenError("Not Authorized");
+        if(!req.user)  throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto")
+        if(!req.rbac.isAllowed(req.user.id, DOCKER_VIEW)) throw new ForbiddenError("Not Authorized")
 
-        let r = await serviceStats(req.params.serviceId)
-        res.json(r)
+        res.json(await serviceStats(req.params.serviceId))
+    } catch (error) {
+        const statusCode = (error.statusCode && validateStatusCode(error.statusCode)) ? error.statusCode : 500
 
-    } catch (e) {
-        let statusCode = (e.statusCode && validateStatusCode(e.statusCode)) ? e.statusCode : 500
         res.status(statusCode)
-        res.send(e.message)
+        res.send(error.message)
     }
 })
 

--- a/apps/backend/src/modules/docker/routes/DockerServiceRoutes.js
+++ b/apps/backend/src/modules/docker/routes/DockerServiceRoutes.js
@@ -7,7 +7,7 @@ import {
     findServiceTag
 } from "../services/DockerService";
 import http from "http";
-import { serviceStatsByName } from "../services/DockerStatsService";
+import { serviceStats, serviceStatsByName } from "../services/DockerStatsService";
 import { AuthenticationError, ForbiddenError } from 'apollo-server-express';
 import { DOCKER_CREATE, DOCKER_UPDATE, DOCKER_VIEW } from '../permissions/dockerPermissions';
 

--- a/apps/backend/src/modules/docker/routes/DockerServiceRoutes.js
+++ b/apps/backend/src/modules/docker/routes/DockerServiceRoutes.js
@@ -27,28 +27,29 @@ router.get('/docker/service', async function (req, res) {
         res.json(await fetchService())
     } catch (error) {
         const statusCode = (error.statusCode && validateStatusCode(error.statusCode)) ? error.statusCode : 500
-
-        res.status(statusCode)
-        res.send(error.message)
+        res.status(statusCode).send(error.message)
     }
 })
 
 
 router.post('/docker/service', async function (req, res) {
     try {
-        if(!req.user)  throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto")
-        if(!req.rbac.isAllowed(req.user.id, DOCKER_CREATE)) throw new ForbiddenError("Not Authorized")
+        if (!req.user) throw new AuthenticationError("Usted no esta autenticado o su token es incorrecto")
+        if (!req.rbac.isAllowed(req.user.id, DOCKER_CREATE)) throw new ForbiddenError("Not Authorized")
 
         res.json(await dockerServiceCreate(req.user, req.body))
     } catch (error) {
         const statusCode = (error.statusCode && validateStatusCode(error.statusCode)) ? error.statusCode : 500
 
         if (error.message.includes('Service already exists')) {
-            const existentServiceID = error.message.match(/[a-z0-9]{25}/)[0]
-            res.json(await dockerServiceUpdate(req.user, existentServiceID, req.body))
+            try {
+                const existentServiceID = error.message.match(/[a-z0-9]{25}/)[0]
+                res.json(await dockerServiceUpdate(req.user, existentServiceID, req.body))
+            } catch (error) {
+                res.status(statusCode).send(`The service already existed and an error happened when we tried to update it: '${error.message}'`)
+            }
         } else {
-            res.status(statusCode)
-            res.send(error.message)    
+            res.status(statusCode).send(error.message)    
         }
     }
 })
@@ -61,9 +62,7 @@ router.put('/docker/service/:service', async function (req, res) {
         res.json(await dockerServiceUpdate(req.user, req.params.service, req.body))
     } catch (error) {
         const statusCode = (error.statusCode && validateStatusCode(error.statusCode)) ? error.statusCode : 500
-
-        res.status(statusCode)
-        res.send(error.message)
+        res.status(statusCode).send(error.message)
     }
 })
 
@@ -74,8 +73,7 @@ router.get('/docker/service/:name', async function (req, res) {
 
         res.json(await findServiceByName(req.params.name))
     } catch (error) {
-        res.status(error.message === "Service not found" ? 404 : 500)
-        res.send(error.message)
+        res.status(error.message === "Service not found" ? 404 : 500).send(error.message)
     }
 })
 
@@ -87,9 +85,7 @@ router.get('/docker/service/:name/tag', async function (req, res) {
         res.json(await findServiceTag(req.params.name))
     } catch (error) {
         const statusCode = (error.statusCode && validateStatusCode(error.statusCode)) ? error.statusCode : 500
-
-        res.status(statusCode)
-        res.send(error.message)
+        res.status(statusCode).send(error.message)
     }
 })
 
@@ -102,9 +98,7 @@ router.get('/docker/service/:serviceName/stats', async function (req, res) {
         res.json(await serviceStatsByName(req.params.serviceName))
     } catch (error) {
         const statusCode = (error.statusCode && validateStatusCode(error.statusCode)) ? error.statusCode : 500
-
-        res.status(statusCode)
-        res.send(error.message)
+        res.status(statusCode).send(error.message)
     }
 })
 
@@ -116,9 +110,7 @@ router.get('/docker/service/id/:serviceId/stats', async function (req, res) {
         res.json(await serviceStats(req.params.serviceId))
     } catch (error) {
         const statusCode = (error.statusCode && validateStatusCode(error.statusCode)) ? error.statusCode : 500
-
-        res.status(statusCode)
-        res.send(error.message)
+        res.status(statusCode).send(error.message)
     }
 })
 


### PR DESCRIPTION
+ refactored code to improve readability and to be cleaner