### PR TITLE
feat: Update logic to return false if any directory doesn't exist

### DIFF
--- a/apps/backend/src/modules/docker/helpers/checkMountedVolumes.js
+++ b/apps/backend/src/modules/docker/helpers/checkMountedVolumes.js
@@ -2,25 +2,27 @@ const { getSettingsValueByKey } = require('@dracul/settings-backend');
 const fs = require('fs');
 
 const checkIfMountedDirectoriesExists = async function() {
-    
+  try {
     const directories = await getSettingsValueByKey('volumes')
-
-    let result = null
-
-    try {
-        directories.forEach(directory => {
-            result = fs.existsSync(directory)
-            console.log(`checkIfMountedDirectoriesExists result: '${result}'. Last directory checked: '${directory}'`)
-        })
-
-        return result
-    } catch (error) {
-        console.error(`An error happened at checkIfMountedDirectoriesExists: '${error}'`)
-        throw error
+    
+    for (let i = 0; i < directories.length; i++) {
+      const directory = directories[i]
+      
+      if (!fs.existsSync(directory)) {
+        console.log(`Directory does not exist: '${directory}'`)
+        return false
+      }
     }
+    
+    console.log('All directories exist.')
+    return true
+  } catch (error) {
+    console.error(`An error occurred at checkIfMountedDirectoriesExists: '${error}'`)
+    throw error
+  }
 }
 
 const notMountedMessage = 'The needed directories are not mounted; please contact your infrastructure team!'
 
-module.exports.checkIfMountedDirectoriesExists = checkIfMountedDirectoriesExists
-module.exports.notMountedMessage = notMountedMessage
+module.exports.checkIfMountedDirectoriesExists = checkIfMountedDirectoriesExists;
+module.exports.notMountedMessage = notMountedMessage;


### PR DESCRIPTION
- Modify the code to check if any directory doesn't exist
- Replace forEach loop with a for loop for early termination

This commit updates the logic in the checkIfMountedDirectoriesExists function to return false if any of the directories specified in the settings are not found. The code now uses fs.existsSync to check the existence of each directory and terminates the loop if a directory doesn't exist. This ensures that the result is false when any directory is missing.

Closes #84752